### PR TITLE
fix uint32_t build error

### DIFF
--- a/src/utils.h
+++ b/src/utils.h
@@ -27,6 +27,7 @@
 #include <set>
 #include <map>
 #include <vector>
+#include <cstdint>
 #include <unistd.h>
 #include <sys/syscall.h>
 #define gettid() syscall(SYS_gettid)


### PR DESCRIPTION
cstdint include is required for definition of uint32_t with gcc 13.2 and Ubuntu 23.10

Example build error:
```
[ 21%] Building CXX object src/CMakeFiles/zerosum.dir/utils.cpp.o
In file included from /home/carns/working/src/mochi/zerosum/src/utils.cpp:30:
/home/carns/working/src/mochi/zerosum/src/utils.h:40:13: error: ‘uint32_t’ was not declared in this scope
   40 | std::vector<uint32_t> parseDiscreteValues(std::string inputString);
      |             ^~~~~~~~
/home/carns/working/src/mochi/zerosum/src/utils.h:32:1: note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
   31 | #include <sys/syscall.h>
  +++ |+#include <cstdint>
   32 | #define gettid() syscall(SYS_gettid)
```