### PR TITLE
fix ‘uint32_t’ has not been declared error

### DIFF
--- a/src/post-processing/mpi_p2p_merge.cpp
+++ b/src/post-processing/mpi_p2p_merge.cpp
@@ -28,6 +28,7 @@ done
 #include <regex>
 #include <algorithm>
 #include <vector>
+#include <cstdint>
 
 void write_vector(
     const std::vector<std::vector<size_t>>& data,


### PR DESCRIPTION
Fixes build error with gcc 13.2 on Ubuntu 24.04