### PR TITLE
resolve warnings about fgets dest buffer sz

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -339,7 +339,7 @@ std::map<std::string,std::string> parseNodeInfo(void) {
         perror ("Error opening file");
         return fields;
     }
-    while ( fgets( line, 4096, pFile)) {
+    while ( fgets( line, 128, pFile)) {
         std::string tmp(line);
         const std::regex separator(":");
         std::sregex_token_iterator token(tmp.begin(), tmp.end(),
@@ -366,7 +366,7 @@ size_t parseMaxPid(void) {
         perror ("Error opening file");
         return maxpid;
     }
-    while ( fgets( line, 4096, pFile)) {
+    while ( fgets( line, 128, pFile)) {
         maxpid = atol(line);
     }
     fclose(pFile);


### PR DESCRIPTION
gcc 13.2 detects that the character array declared on the stack isn't long enough for the fgets arguments and issues a warning